### PR TITLE
RNMT-1853 Fixes Cipher Local Storage key fetch mechanism

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Additions
+- Disables Android Auto Backup for apps [RNMT-1853](https://outsystemsrd.atlassian.net/browse/RNMT-1853)
+
+### Fixes
+- Fixes Cipher Local Storage key fetch mechanism [RNMT-1853](https://outsystemsrd.atlassian.net/browse/RNMT-1853)
+
+## 1.1.1 - 2019-01-30
+### Additions
+- Updates cordova-sqlcipher-adapter to version 0.1.7-os.3 [RNMT-2530](https://outsystemsrd.atlassian.net/browse/RNMT-2530)
+
+[Unreleased]: https://github.com/OutSystems/cordova-outsystems-secure-sqlite-bundle/compare/1.1.1...HEAD
+[1.1.1]: https://github.com/OutSystems/cordova-outsystems-secure-sqlite-bundle/compare/1.1.0...1.1.1

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ window.sqlitePlugin.openDatabase(options, successCallback, errorCallback);
 
 Refer to the Cordova SQLCipher Adapter plugin documentation for samples and details of the supported features.
 
+## Limitations
+Android Auto Backup for Apps is not compatible with Cipher Local Storage plugin which automatically backs up a user's data from apps that target and run on Android 6.0 (API level 23) or later in enabled in settings. Said that AndroidManifest.xml is modified to disable auto backup by setting android:allowBackup attribute to false, avoiding backing up or restoring the app data.
+
 ## Known Issues
 - The usage of the SecureStorage plugin requires **Android devices** to have a PIN (or similar) set. Removal of the PIN will effectively **render the database unreadable**, as the key will be lost.
 - It is not possible to open existing databases that are not encrypted.

--- a/hooks/disableAndroidBackup.js
+++ b/hooks/disableAndroidBackup.js
@@ -1,0 +1,90 @@
+// Global vars
+var deferral, fs, elementtree, path;
+
+var disableAllowBackup = (function () {
+
+    var disableAllowBackup = {};
+
+    var manifestPaths = {
+        cordovaAndroid6: "platforms/android/AndroidManifest.xml",
+        cordovaAndroid7: "platforms/android/app/src/main/AndroidManifest.xml"
+    };
+
+    var rootDir;
+
+    disableAllowBackup.fileExists = function (filePath) {
+        try {
+            return fs.statSync(filePath).isFile();
+        } catch (error) {
+            return false;
+        }
+    };
+
+    disableAllowBackup.parseElementtreeSync = function (filename) {
+        var content = fs.readFileSync(filename, 'utf-8');
+        return new elementtree.ElementTree(elementtree.XML(content));
+    };
+
+    disableAllowBackup.getAndroidManifestPath = function () {
+        var cordovaAndroid6Path = path.join(rootDir, manifestPaths.cordovaAndroid6);
+        var cordovaAndroid7Path = path.join(rootDir, manifestPaths.cordovaAndroid7);
+
+        if (this.fileExists(cordovaAndroid6Path)) {
+            return cordovaAndroid6Path;
+        } else if (this.fileExists(cordovaAndroid7Path)) {
+            return cordovaAndroid7Path;
+        } else {
+            return undefined;
+        }
+    };
+
+
+    disableAllowBackup.apply = function (ctx) {
+        debugger;
+        rootDir = ctx.opts.projectRoot;
+
+        var androidManifestPath = this.getAndroidManifestPath();
+        if(!androidManifestPath) {
+            throw new Error("Unable to find AndroidManifest.xml");
+        }
+        
+        var manifestTree = this.parseElementtreeSync(androidManifestPath);
+        var root = manifestTree.getroot();
+
+        if (root) {
+            var applicationElement = root.find("./application");
+            if (applicationElement) {
+                root.set("xmlns:tools", "http://schemas.android.com/tools");
+                applicationElement.set("android:allowBackup", "false");
+                applicationElement.set("tools:replace", "android:allowBackup");
+            } else {
+                throw new Error("Invalid AndroidManifest.xml structure. No <application> tag found.");
+            }
+
+            fs.writeFileSync(androidManifestPath, manifestTree.write({indent:4}, 'utf-8'));
+        } else {
+            throw new Error("Invalid AndroidManifest.xml structure. No <manifest> tag found.");
+        }
+    };
+
+    return disableAllowBackup;
+})();
+
+module.exports = function (ctx) {
+    var Q = ctx.requireCordovaModule("q");
+    fs = ctx.requireCordovaModule("fs");
+    path = ctx.requireCordovaModule("path");
+    elementtree = ctx.requireCordovaModule("elementtree");
+
+    deferral = Q.defer();
+
+    try {
+        disableAllowBackup.apply(ctx);
+        deferral.resolve();
+    } catch (error) {
+        deferral.reject(error);
+        return deferral.promise;
+    }
+
+    return deferral.promise;
+};

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
     <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git" commit="0.1.7-os.3" />
     <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git" commit="2.6.8" />
-    <dependency id="cordova-outsystems-logger" url="https://e65fec09fc31747a2a0e455c0757dcf2cf786a63:@github.com/OutSystems/cordova-outsystems-logger.git" commit="1.3.1" />
+    <dependency id="com.outsystems.plugins.logger" url="https://e65fec09fc31747a2a0e455c0757dcf2cf786a63:@github.com/OutSystems/cordova-outsystems-logger.git" commit="1.3.1" />
 
 
     <engines>

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,6 +21,15 @@
     <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git" commit="0.1.7-os.3" />
     <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git" commit="2.6.8" />
 
+    <engines>
+        <engine name="cordova" version=">=6.4.0"/>
+        <engine name="cordova-android" version=">=6.0.0"/>
+    </engines>
+
+    <platform name="android">
+        <hook type="before_compile" src="hooks/disableAndroidBackup.js"/>
+    </platform>
+
 </plugin>
 
 <!-- vim: set expandtab : -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
     <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git" commit="0.1.7-os.3" />
     <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git" commit="2.6.8" />
-    <dependency id="com.outsystems.plugins.logger" url="https://e65fec09fc31747a2a0e455c0757dcf2cf786a63:@github.com/OutSystems/cordova-outsystems-logger.git" commit="1.3.1" />
+    <dependency id="com.outsystems.plugins.logger" />
 
 
     <engines>

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,6 +20,8 @@
 
     <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git" commit="0.1.7-os.3" />
     <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git" commit="2.6.8" />
+    <dependency id="cordova-outsystems-logger" url="https://e65fec09fc31747a2a0e455c0757dcf2cf786a63:@github.com/OutSystems/cordova-outsystems-logger.git" commit="1.3.1" />
+
 
     <engines>
         <engine name="cordova" version=">=6.4.0"/>

--- a/www/outsystems-secure-sqlite-init.js
+++ b/www/outsystems-secure-sqlite-init.js
@@ -11,10 +11,38 @@ if (typeof(window.sqlitePlugin.openDatabase) !== "function") {
     throw new Error("Dependencies were not loaded correctly: window.sqlitePlugin does not provide an `openDatabase` function.");
 }
 
-var OUTSYSTEMS_KEYSTORE = "outsystems-key-store"
+var OUTSYSTEMS_KEYSTORE = "outsystems-key-store";
 var LOCAL_STORAGE_KEY = "outsystems-local-storage-key";
 
 var lskCache = "";
+
+/**
+ * https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0
+ * 
+ * Returns a hash code for a string.
+ * (Compatible to Java's String.hashCode())
+ *
+ * The hash code for a string object is computed as
+ *     s[0]*31^(n-1) + s[1]*31^(n-2) + ... + s[n-1]
+ * using number arithmetic, where s[i] is the i th character
+ * of the given string, n is the length of the string,
+ * and ^ indicates exponentiation.
+ * (The hash value of the empty string is zero.)
+ *
+ * @param {string} s a string
+ * @return {number} a hash code value for the given string.
+ */
+var hashCode = function(s) {
+    if (!s) {
+        return 0;
+    }
+
+    var h = 0, l = s.length, i = 0;
+    if ( l > 0 )
+        while (i < l)
+            h = (h << 5) - h + s.charCodeAt(i++) | 0;
+    return h;
+}
 
 /**
  * Provides the currently stored Local Storage Key or generates a new one.
@@ -33,31 +61,52 @@ function acquireLsk(successCallback, errorCallback) {
     var initFn = function() {
         var ss = new SecureStorage(
             function () {
-                // and when initialized attempt to get the stored key
-                ss.get(
-                    function (value) {
-                        lskCache = value;
-                        console.log("Got Local Storage key");
-                        successCallback(lskCache);
-                    },
-                    function (error) {
-                        // If there's no key yet, generate a new one and store it
-                        var newKey = generateKey();
-                        lskCache = undefined;
-                        console.log("Setting new Local Storage key");
-                        ss.set(
-                            function (key) {
-                                lskCache = newKey;
-                                successCallback(lskCache);
-                            },
-                            errorCallback,
-                            LOCAL_STORAGE_KEY,
-                            newKey);
-                    },
-                    LOCAL_STORAGE_KEY);
+                rewriteLsk(ss, function(){
+                    // Now, lets try to get all keys from OutSystems keystore
+                    ss.keys(
+                        function (keys) {
+                            //Check if OutSystems local key exists
+                            if(keys.indexOf(LOCAL_STORAGE_KEY) >= 0) {
+                                // If succeded, attempt to get OutSystems local key
+                                ss.get(
+                                    function (value) {
+                                        lskCache = value;
+                                        successCallback(lskCache);
+                                    },
+                                    function (error) {
+                                        OutSystemsNative.Logger.logError("Error getting local storage key from keychain: " + error, "SecureSQLiteBundle");
+                                        errorCallback(error);
+                                    },
+                                    LOCAL_STORAGE_KEY);
+                            } else {
+                                // Otherwise, set a new OutSystems key
+                                // If there's no key yet, generate a new one and store it
+                                var newKey = generateKey();
+                                lskCache = undefined;
+                                ss.set(
+                                    function (key) {
+                                        OutSystemsNative.Logger.logWarning("Setting new local storage key.", "SecureSQLiteBundle");
+                                        lskCache = newKey;
+                                        successCallback(lskCache);
+                                    },
+                                    function (error) {
+                                        OutSystemsNative.Logger.logError("Error generating new local storage key: " + error, "SecureSQLiteBundle");
+                                        errorCallback(error);
+                                    },
+                                    LOCAL_STORAGE_KEY,
+                                    newKey);
+                            }
+                        },
+                        function (error) {
+                            OutSystemsNative.Logger.logError("Error while getting local storage key: " + error, "SecureSQLiteBundle");
+                            errorCallback(error);
+                        }
+                    );
+                });
             },
             function(error) {
                 if (error.message === "Device is not secure") {
+                    OutSystemsNative.Logger.logError("Device is not secure.", "SecureSQLiteBundle");
                     if (window.confirm("In order to use this app, your device must have a secure lock screen. Press OK to setup your device.")) {
                         ss.secureDevice(
                             initFn,
@@ -72,10 +121,29 @@ function acquireLsk(successCallback, errorCallback) {
                     errorCallback(error);
                 }
             },
-            OUTSYSTEMS_KEYSTORE);
-     };
+        OUTSYSTEMS_KEYSTORE);
+    };
+    initFn();
+}
 
-     initFn();
+// Method to rewrite Local Storage Key into keychain
+function rewriteLsk(ss, callback) {
+	ss.get(
+		function (value) {
+			ss.set(
+				function (key) {
+					callback();
+				},
+				function (error) {
+					callback();
+				},
+			LOCAL_STORAGE_KEY,
+			value);
+		},
+		function (error) {
+			callback();
+		},
+	LOCAL_STORAGE_KEY);
 }
 
 /**

--- a/www/outsystems-secure-sqlite-init.js
+++ b/www/outsystems-secure-sqlite-init.js
@@ -1,7 +1,7 @@
 // Force dependency load
 var SQLiteCipher = require('cordova-sqlcipher-adapter.SQLitePlugin');
 var SecureStorage = require('cordova-plugin-secure-storage.SecureStorage');
-var OutSystemsNative = require('cordova-outsystems-logger.OutSystemsNative');
+var Logger = require('com.outsystems.plugins.logger.OSLogger');
 
 // Validate SQLite plugin API is properly set
 if (typeof(window.sqlitePlugin) === "undefined") {
@@ -75,7 +75,7 @@ function acquireLsk(successCallback, errorCallback) {
                                         successCallback(lskCache);
                                     },
                                     function (error) {
-                                        OutSystemsNative.Logger.logError("Error getting local storage key from keychain: " + error, "SecureSQLiteBundle");
+                                        Logger.logError("Error getting local storage key from keychain: " + error, "SecureSQLiteBundle");
                                         errorCallback(error);
                                     },
                                     LOCAL_STORAGE_KEY);
@@ -86,12 +86,12 @@ function acquireLsk(successCallback, errorCallback) {
                                 lskCache = undefined;
                                 ss.set(
                                     function (key) {
-                                        OutSystemsNative.Logger.logWarning("Setting new local storage key.", "SecureSQLiteBundle");
+                                        Logger.logWarning("Setting new local storage key.", "SecureSQLiteBundle");
                                         lskCache = newKey;
                                         successCallback(lskCache);
                                     },
                                     function (error) {
-                                        OutSystemsNative.Logger.logError("Error generating new local storage key: " + error, "SecureSQLiteBundle");
+                                        Logger.logError("Error generating new local storage key: " + error, "SecureSQLiteBundle");
                                         errorCallback(error);
                                     },
                                     LOCAL_STORAGE_KEY,
@@ -99,7 +99,7 @@ function acquireLsk(successCallback, errorCallback) {
                             }
                         },
                         function (error) {
-                            OutSystemsNative.Logger.logError("Error while getting local storage key: " + error, "SecureSQLiteBundle");
+                            Logger.logError("Error while getting local storage key: " + error, "SecureSQLiteBundle");
                             errorCallback(error);
                         }
                     );
@@ -107,7 +107,7 @@ function acquireLsk(successCallback, errorCallback) {
             },
             function(error) {
                 if (error.message === "Device is not secure") {
-                    OutSystemsNative.Logger.logError("Device is not secure.", "SecureSQLiteBundle");
+                    Logger.logError("Device is not secure.", "SecureSQLiteBundle");
                     if (window.confirm("In order to use this app, your device must have a secure lock screen. Press OK to setup your device.")) {
                         ss.secureDevice(
                             initFn,

--- a/www/outsystems-secure-sqlite-init.js
+++ b/www/outsystems-secure-sqlite-init.js
@@ -126,7 +126,14 @@ function acquireLsk(successCallback, errorCallback) {
     initFn();
 }
 
-// Method to rewrite Local Storage Key into keychain
+/** 
+ * Method to rewrite Local Storage Key into keychain
+ * 
+ * This method was created to bypass secure storage update issue.
+ * The keys() method was returning null if the entries were written
+ * with an older version of Secure Storage plugin.
+ * 
+**/
 function rewriteLsk(ss, callback) {
 	ss.get(
 		function (value) {

--- a/www/outsystems-secure-sqlite-init.js
+++ b/www/outsystems-secure-sqlite-init.js
@@ -1,6 +1,7 @@
 // Force dependency load
 var SQLiteCipher = require('cordova-sqlcipher-adapter.SQLitePlugin');
 var SecureStorage = require('cordova-plugin-secure-storage.SecureStorage');
+var OutSystemsNative = require('cordova-outsystems-logger.OutSystemsNative');
 
 // Validate SQLite plugin API is properly set
 if (typeof(window.sqlitePlugin) === "undefined") {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes method to fetch the Cipher Local Storage key from the keychain and disables Android Auto Backup for apps using this plugin.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Fixes https://outsystemsrd.atlassian.net/browse/RNMT-1853

<!--- Why is this change required? What problem does it solve? -->
This is required in order to ensure the correctness of the mechanism that fetches the encryption key used to cipher the local storage. Also, since Android Auto Backup was backing up encrypted tables, when a new installation was made, the app's data was restored (encrypted with an old key) and the tables could no longer be accessed.

For more information check the support case previously mentioned.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [x] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Manual verification was conducted to validate the reported behavior an issue was no longer replicated.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [x] Documentation has been updated accordingly