### PR TITLE
RNMT-2669 Cipher Plugin - Support to 64-bits

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Support to 64-bits [RNMT-2669](https://outsystemsrd.atlassian.net/browse/RNMT-2669)
+
 ### Additions
 - Disables Android Auto Backup for apps [RNMT-1853](https://outsystemsrd.atlassian.net/browse/RNMT-1853)
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -14,7 +14,7 @@
         <clobbers target="OutSystemsSecureSQLiteBundle" />
     </js-module>
 
-    <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git" commit="RNMT-2669-64bits" />
+    <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git" commit="0.1.7-OS5" />
     <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git" commit="2.6.8" />
     
     <dependency id="outsystems-plugin-disable-backup" url="https://github.com/OutSystems/outsystems-plugin-disable-backup.git" commit="1.0.0" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -14,7 +14,7 @@
         <clobbers target="OutSystemsSecureSQLiteBundle" />
     </js-module>
 
-    <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git" commit="0.1.7-OS4" />
+    <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git" commit="RNMT-2669-64bits" />
     <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git" commit="2.6.8" />
     
     <dependency id="outsystems-plugin-disable-backup" url="https://github.com/OutSystems/outsystems-plugin-disable-backup.git" commit="1.0.0" />


### PR DESCRIPTION
## Description
This PR includes the support of 64-bits libraries (provided by the version **0.1.7-OS5 from Cordova-sqlcipher-adapter**).

This new version includes: 
- Two new arch to support 64-bits (arm64-v8a and x86_64)
- Other libs updated to include the latest version from the PR **[RNMT-2669 Cipher Plugin - Support to 64-bits](https://github.com/OutSystems/android-database-sqlcipher/pull/2)**

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
References https://outsystemsrd.atlassian.net/browse/RNMT-2669

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Native Code
- [ ] JS API

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Manual tests have been performed (using **Test Plugins App with Ciphered**, a custom app using **Barcode Scanner + CardIO + Cipher Local Storage** plugin) and a customer app (from Personal Group). **Automatic tests and QA certification are currently on-going.**

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly