### PR TITLE
chore: updates version of cordova-plugin-secure-storage to 2.6.8-OS

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changes
+- Updates version of cordova-plugin-secure-storage to 2.6.8-OS [RNMT-3257](https://outsystemsrd.atlassian.net/browse/RNMT-3257)
+
 ## 2.0.0 - 2019-06-12
 ### Additions
 - Support to 64-bits [RNMT-2669](https://outsystemsrd.atlassian.net/browse/RNMT-2669)

--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,7 @@
     </js-module>
 
     <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git" commit="0.1.7-OS5" />
-    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git" commit="2.6.8" />
+    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git" commit="2.6.8-OS" />
     
     <dependency id="outsystems-plugin-disable-backup" url="https://github.com/OutSystems/outsystems-plugin-disable-backup.git" commit="1.0.0" />
     <dependency id="com.outsystems.plugins.logger" />


### PR DESCRIPTION
Updates version of cordova-plugin-secure-storage to 2.6.8-OS