### PR TITLE
RNMT-3824 Errors in the first reads/writes of a Key Store when multiple initializations run simultaneously

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -8,13 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 2.0.3 - 2020-01-21
 ### Changes
-- Update version of cordova-plugin-secure-storage to 2.6.8-OS2 [RNMT-3604](https://outsystemsrd.atlassian.net/browse/RNMT-3604)
-
-### Fixes
-- Lock screen authentication can no longer be bypassed in Android 10 devices [RNMT-3604](https://outsystemsrd.atlassian.net/browse/RNMT-3604)
-
-## 2.0.2 - 2019-12-26
-### Changes
 - Update version of cordova-plugin-secure-storage to 2.6.8-OS1 [RNMT-3540](https://outsystemsrd.atlassian.net/browse/RNMT-3540)
 
 ## 2.0.1 - 2019-09-04

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,8 +5,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changes
+- Update version of cordova-plugin-secure-storage to 2.6.8-OS3 [RNMT-3824](https://outsystemsrd.atlassian.net/browse/RNMT-3824)
+
+### Removals
+- Revert: Lock screen authentication can no longer be bypassed in Android 10 devices [RNMT-3604](https://outsystemsrd.atlassian.net/browse/RNMT-3604)
 
 ## 2.0.3 - 2020-01-21
+### Changes
+- Update version of cordova-plugin-secure-storage to 2.6.8-OS2 [RNMT-3604](https://outsystemsrd.atlassian.net/browse/RNMT-3604)
+
+### Fixes
+- Lock screen authentication can no longer be bypassed in Android 10 devices [RNMT-3604](https://outsystemsrd.atlassian.net/browse/RNMT-3604)
+
+## 2.0.2 - 2019-12-26
 ### Changes
 - Update version of cordova-plugin-secure-storage to 2.6.8-OS1 [RNMT-3540](https://outsystemsrd.atlassian.net/browse/RNMT-3540)
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,7 @@
     </js-module>
 
     <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git" commit="0.1.7-OS5" />
-    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git" commit="2.6.8-OS1" />
+    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git" commit="2.6.8-OS3" />
     
     <dependency id="outsystems-plugin-disable-backup" url="https://github.com/OutSystems/outsystems-plugin-disable-backup.git" commit="1.0.0" />
     <dependency id="com.outsystems.plugins.logger" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,7 @@
     </js-module>
 
     <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git" commit="0.1.7-OS5" />
-    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git" commit="2.6.8-OS2" />
+    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git" commit="2.6.8-OS1" />
     
     <dependency id="outsystems-plugin-disable-backup" url="https://github.com/OutSystems/outsystems-plugin-disable-backup.git" commit="1.0.0" />
     <dependency id="com.outsystems.plugins.logger" />

--- a/www/outsystems-secure-sqlite-init.js
+++ b/www/outsystems-secure-sqlite-init.js
@@ -79,7 +79,6 @@ function acquireLsk(successCallback, errorCallback) {
                 });
             },
             function(error) {
-                // When no lock screen is configured in the device
                 if (error.message === "Device is not secure") {
                     Logger.logError("Device is not secure.", "SecureSQLiteBundle");
                     if (window.confirm("In order to use this app, your device must have a secure lock screen. Press OK to setup your device.")) {
@@ -92,12 +91,6 @@ function acquireLsk(successCallback, errorCallback) {
                     } else {
                         navigator.app.exitApp();
                     }
-                // When the user cancelled or failed to unlock the lock screen
-                } else if (error.message === "Authentication failed") {
-                    Logger.logError("Authentication failed.", "SecureSQLiteBundle");
-                    window.alert("In order to use this app, you must authenticate in the secure lock screen.");
-                    navigator.app.exitApp();
-                // Otherwise
                 } else {
                     errorCallback(error);
                 }


### PR DESCRIPTION
## Description
Reverts the previous fix.
Raises the used version of the Key Store Plugin.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Fixes https://outsystemsrd.atlassian.net/browse/RNMT-3824

<!--- Why is this change required? What problem does it solve? -->
This commit raises the used version of the Key Store Plugin. It mostly does not affect this plugin, but we should raise this to the latest version available.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Manual tests were performed

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly