### PR TITLE
RMET-1191 Cipher Plugin - Update adapter dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.11] - 2021-11-09
+### Fixes
+- New plugin release to include metadata tag in Extensibility Configurations in the OS wrapper
+
 ## [2.0.10] - 2021-11-04
 ### Fixes
 - New plugin release to include metadata tag in Extensibility Configurations in the OS wrapper
@@ -68,7 +73,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Additions
 - Updates cordova-sqlcipher-adapter to version 0.1.7-os.3 [RNMT-2530](https://outsystemsrd.atlassian.net/browse/RNMT-2530)
 
-[Unreleased]: https://github.com/OutSystems/cordova-outsystems-secure-sqlite-bundle/compare/2.0.10...HEAD
+[Unreleased]: https://github.com/OutSystems/cordova-outsystems-secure-sqlite-bundle/compare/2.0.11...HEAD
+[2.0.10]: https://github.com/OutSystems/cordova-outsystems-secure-sqlite-bundle/compare/2.0.10...2.0.11
 [2.0.10]: https://github.com/OutSystems/cordova-outsystems-secure-sqlite-bundle/compare/2.0.9...2.0.10
 [2.0.9]: https://github.com/OutSystems/cordova-outsystems-secure-sqlite-bundle/compare/2.0.8...2.0.9
 [2.0.8]: https://github.com/OutSystems/cordova-outsystems-secure-sqlite-bundle/compare/2.0.7...2.0.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.0.11] - 2021-11-09
 ### Fixes
-- New plugin release to include metadata tag in Extensibility Configurations in the OS wrapper
+- Fix: Improved self-healing policy, by updating dependency to sql-adapter (https://outsystemsrd.atlassian.net/browse/RMET-1191)
 
 ## [2.0.10] - 2021-11-04
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updates cordova-sqlcipher-adapter to version 0.1.7-os.3 [RNMT-2530](https://outsystemsrd.atlassian.net/browse/RNMT-2530)
 
 [Unreleased]: https://github.com/OutSystems/cordova-outsystems-secure-sqlite-bundle/compare/2.0.11...HEAD
-[2.0.10]: https://github.com/OutSystems/cordova-outsystems-secure-sqlite-bundle/compare/2.0.10...2.0.11
+[2.0.11]: https://github.com/OutSystems/cordova-outsystems-secure-sqlite-bundle/compare/2.0.10...2.0.11
 [2.0.10]: https://github.com/OutSystems/cordova-outsystems-secure-sqlite-bundle/compare/2.0.9...2.0.10
 [2.0.9]: https://github.com/OutSystems/cordova-outsystems-secure-sqlite-bundle/compare/2.0.8...2.0.9
 [2.0.8]: https://github.com/OutSystems/cordova-outsystems-secure-sqlite-bundle/compare/2.0.7...2.0.8

--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,7 @@
     </js-module>
 
     <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git#fix/RMET-1191/improve-self-heal" />
-    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#2.6.8-OS6" />
+    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#2.6.8-OS7" />
     
     <dependency id="outsystems-plugin-disable-backup" url="https://github.com/OutSystems/outsystems-plugin-disable-backup.git#1.0.2" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -14,7 +14,7 @@
         <clobbers target="OutSystemsSecureSQLiteBundle" />
     </js-module>
 
-    <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git#0.1.7-OS6" />
+    <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git#fix/RMET-1191/improve-self-heal" />
     <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#2.6.8-OS6" />
     
     <dependency id="outsystems-plugin-disable-backup" url="https://github.com/OutSystems/outsystems-plugin-disable-backup.git#1.0.2" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -14,7 +14,7 @@
         <clobbers target="OutSystemsSecureSQLiteBundle" />
     </js-module>
 
-    <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git#fix/RMET-1191/improve-self-heal" />
+    <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git#0.1.7-OS7" />
     <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#2.6.8-OS7" />
     
     <dependency id="outsystems-plugin-disable-backup" url="https://github.com/OutSystems/outsystems-plugin-disable-backup.git#1.0.2" />


### PR DESCRIPTION
## Description

- This PR updates the dependency to the `cordova-sqlcipher-adapter` plugin. It also updates the dependency to the latest version of the `cordova-plugin-secure-storage.git`, that we released because of the `metadata` update in the Extensability Configurations for MABS 8.
- The update of `cordova-sqlcipher-adapter` solves the issue in the context.

## Context
<!--- Why is this change required? What problem does it solve? -->
https://outsystemsrd.atlassian.net/browse/RMET-1191


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
Tested locally in Android Studio. MABS 7 and 8 working. Also tested with APKs built by MABS.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly