### PR TITLE
RPM-2504 ::: Avoid Keychain's errSecInteractionNotAllowed error on iOS 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.15] - 2022-04-14
+### Fixes
+- Fix: For iOS 15, on the `init` method, if ProtectedData is unavailable, add an observer for the `UIApplicationProtectedDataDidBecomeAvailable` notification that re-triggers `init` when it becomes available. (RMET-1417)
+
 ## [2.0.14] - 2022-04-12
 ### Fixes
 - Fix: Fix for the error messages: Keystore operation failed, User not authenticated, Key not yet valid. (RMET-1182)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.SecureSQLiteBundle",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "Bundle of SQLite related storage plugins and initialization code for easy use with the OutSystems Platform",
   "cordova": {
     "id": "com.outsystems.plugins.SecureSQLiteBundle",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="com.outsystems.plugins.SecureSQLiteBundle"
-    version="2.0.14">
+    version="2.0.15">
 
     <name>Cordova OutSystems secure SQLite bundle</name>
     <license>MIT</license>
@@ -15,7 +15,7 @@
     </js-module>
 
     <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git#0.1.7-OS7" />
-    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#2.6.8-OS11" />
+    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#2.6.8-OS12" />
     
     <dependency id="outsystems-plugin-disable-backup" url="https://github.com/OutSystems/outsystems-plugin-disable-backup.git#1.0.2" />
 


### PR DESCRIPTION
## Description
For iOS 15, on `SecureStorage`'s `init` method, if `ProtectedData` is unavailable, add an observer for the `UIApplicationProtectedDataDidBecomeAvailable` notification that re-triggers init when it becomes available.

## Context
https://outsystemsrd.atlassian.net/browse/RPM-2504

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
iOS

## Tests
The issue couldn't be replicated.

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly