### PR TITLE
RMET-1771 Ciphered Plugin - Fixing comparison for migration failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixes - 2022-09-01
+- Fix: Fixing the way we checked the migration failed error (https://outsystemsrd.atlassian.net/browse/RMET-1771)
 
 ## [2.0.15] - 2022-04-14
 ### Fixes

--- a/www/outsystems-secure-sqlite-init.js
+++ b/www/outsystems-secure-sqlite-init.js
@@ -97,7 +97,7 @@ function acquireLsk(successCallback, errorCallback) {
                         navigator.app.exitApp();
                     }
                 // When secure storage key migration fails
-                } else if (error.indexOf("MIGRATION FAILED") === 0) {
+                } else if (error.message.indexOf("MIGRATION FAILED") === 0) {
                     Logger.logError("Migration Failed.", "SecureSQLiteBundle");
                     window.alert("A feature on this app failed to be upgraded. Relaunch the app to try again.");
                     navigator.app.exitApp();


### PR DESCRIPTION
## Description

- `error.indexOf` resulted in an uncaught exception, as there is no `indexOf()` function for the `error` object. Instead, we need to get the `message` first.

- Because of this uncaught exception, an app using the Ciphered Local Storage plugin would be stuck whenever the `error.indexOf` was called in the if-condition.

## Context
References: https://outsystemsrd.atlassian.net/browse/RMET-1771

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] JavaScript
- [x] Android
- [ ] iOS

## Tests
Tested in an app built with MABS 8.1 and returning the migration failed error (forced in the code).

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly