### PR TITLE
RMET-2062 ::: iOS ::: Return Empty Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixes
+- Fix: [iOS] When there are no keys associated with a store, return empty string instead of `nil`.
 
 ## [2.1.1] - 2022-11-09
 ### Features

--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,7 @@
     </js-module>
 
     <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git#0.1.7-OS7" />
-    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#2.6.8-OS14" />
+    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#2.6.8-OS15" />
     
     <dependency id="outsystems-plugin-disable-backup" url="https://github.com/OutSystems/outsystems-plugin-disable-backup.git#1.0.2" />
 


### PR DESCRIPTION
## Description
Update `cordova-plugin-secure-storage` to version `2.6.8-OS15`.

To test the issue, a Sample App build for `Ciphered Local Storage` was created. It can be checked [here](https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=8f75bf7b075ed5d7e14e04f9ff796c9dcef5a196).

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2062

This is a follow up on [this PR](https://github.com/OutSystems/cordova-plugin-secure-storage/pull/21).

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
