### PR TITLE
RMET-2843 ::: SQlite 3.40.1 Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.1.5] - 2023-11-13
+- Fix: [Android/iOS] Update sqlcipher to 4.5.4 and sqlite 3.40.1 (https://outsystemsrd.atlassian.net/browse/RMET-2843).
+
 ## [2.1.4] - 2023-01-20
 - Fix: [Android] Udpate secure-storage version to 2.6.8-OS17 (https://outsystemsrd.atlassian.net/browse/RMET-2190).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.SecureSQLiteBundle",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Bundle of SQLite related storage plugins and initialization code for easy use with the OutSystems Platform",
   "cordova": {
     "id": "com.outsystems.plugins.SecureSQLiteBundle",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="com.outsystems.plugins.SecureSQLiteBundle"
-    version="2.1.4">
+    version="2.1.5">
 
     <name>Cordova OutSystems secure SQLite bundle</name>
     <license>MIT</license>
@@ -14,7 +14,7 @@
         <clobbers target="OutSystemsSecureSQLiteBundle" />
     </js-module>
 
-    <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git#0.1.7-OS7" />
+    <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git#0.1.7-OS8" />
     <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#2.6.8-OS17" />
     
     <dependency id="outsystems-plugin-disable-backup" url="https://github.com/OutSystems/outsystems-plugin-disable-backup.git#1.0.2" />


### PR DESCRIPTION
### Platforms affected
- Android
- iOS

### Motivation and Context
- This PR has the purpose of updating SQLite version to `3.40.1`. This means that SQLCipher it self was updated in order to bring a new SQLite version along;
- Version `3.40.1` was chosen to better align with SQLite `3.40.0` used by MABS;
- We couldn't use `3.40.0` exactly because it isn't available on sqlcipher.

### Description
To update Android platform we needed to update `android-database-sqlcipher`.
This PR is just an update on the android-database-sqlcipher version reference.

### Tests
We tested this on real device by:
 - Running the sample app as normal;
 - Installing the updated version on top of the old one, to test the migration process;