### PR TITLE
RMET-4190 :: Capacitor support + Prepare release of 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2025-06-20
+- Feat: Support for Capacitor apps with OutSystems.
+- Chore: Update dependency to KeyStore plugin to use version `2.6.8-OS22`.
+
 ## [2.1.7] - 2025-02-07
 - Chore: Update dependency to KeyStore plugin to use version `2.6.8-OS21`.
 

--- a/build-actions/README.md
+++ b/build-actions/README.md
@@ -1,0 +1,36 @@
+
+# Build Actions
+
+This folder contains a .yaml file for configuring build actions to use in a plugin on ODC with Capacitor. The purpose of these build actions is to provide the same functionality as cordova hooks, but in a Capacitor shell for OutSystems apps.
+
+## Contents
+
+The file [disable_auto_backups.yaml](./disable_auto_backups.yaml) contains 1 build action:
+
+1. Android specific. Disable auto-backup for the Android application, by changing the `AndroidManifest.xml` file.
+
+
+Furthermore, there are changes that can't be accomplished with build actions, and we used [Capacitor hooks](https://capacitorjs.com/docs/cli/hooks) for this. We have one JavaScript file for hooks:
+
+- [update_strings_for_keystore.js](./update_strings_for_keystore.js) - Update the application's `strings.xml` file that are used for the [KeyStore Plugin](https://github.com/OutSystems/cordova-plugin-secure-storage), which is a dependency of this Cordova plugin. 
+
+Reasoning for this hook: The KeyStore plugin has its own build actions to update these strings, which only triggers from OutSystems apps. The dependency exists only at the Cordova-level, not OutSystems level, and the actual strings aren't meant to be configured here, since they won't actually be used in the plugin, it's just required for the KeyStore plugin initialization. Therefore, this hook only adds the strings to `strings.xml` if they don't already exist yet, to avoid modifying custom strings from the KeyStore Plugin (which can happen if users have an OutSystems app with both Ciphered and KeyStore plugins).
+
+
+## Outsystems' Usage
+
+1. Copy the build action yaml file (which can contain multiple build actions inside) into the ODC Plugin, placing them in "Data" -> "Resources" and set "Deploy Action" to "Deploy to Target Directory", with target directory empty.
+2. Update the Plugin's Extensibility configuration to use the build action.
+
+```json
+{
+    "buildConfigurations": {
+        "buildAction": {
+            "config": $resources.buildActionFileName.yaml,
+            "parameters": {
+                // parameters go here; if there are no parameters then the block can be ommited
+            }
+        }
+    }
+}
+```

--- a/build-actions/disable_auto_backups.yaml
+++ b/build-actions/disable_auto_backups.yaml
@@ -1,0 +1,7 @@
+platforms:
+  android:
+    manifest:
+      - file: AndroidManifest.xml
+        target: manifest/application
+        attrs:
+          android:allowBackup: "false"

--- a/build-actions/update_strings_for_keystore.js
+++ b/build-actions/update_strings_for_keystore.js
@@ -1,0 +1,91 @@
+const path = require('path');
+const fs = require('fs');
+const { DOMParser, XMLSerializer } = require('xmldom');
+
+const parser = new DOMParser();
+const platform = process.env.CAPACITOR_PLATFORM_NAME;
+const projectRoot = process.env.CAPACITOR_ROOT_DIR;
+
+if (platform != 'android') {
+    // hook only needs to run for Android
+    return
+}
+
+console.log("\nCiphered Local Storage Plugin - running hook after update - for " + platform);
+
+const stringsXmlPath = path.join(projectRoot, 'android/app/src/main/res/values/strings.xml');
+const jsonConfigPath = path.join(projectRoot, "capacitor.config.json");
+if (!fs.existsSync(stringsXmlPath)) {
+   console.error("\t[ERROR] - strings.xml file does not exist, and is required by this hook - " + stringsXmlPath);
+   process.exit(1);
+}
+if (!fs.existsSync(jsonConfigPath)) {
+   console.error("\t[ERROR] - capacitor.config.json file does not exist, and is required by this hook - " + jsonConfigPath);
+   process.exit(1);
+}
+
+// read and parse files
+const stringsXmlDoc = parser.parseFromString(fs.readFileSync(stringsXmlPath, 'utf-8'), 'text/xml');
+const configJsonContent = JSON.parse(fs.readFileSync(jsonConfigPath, "utf8"));
+let writtenValuesCount = 0;
+
+// Add  entries only if they are not present
+const valuesToAdd = [
+    { stringsXmlName: 'migration_auth', value: 'false', type: 'bool', configKey: 'MIGRATE_KEYS_AUTH' },
+    { stringsXmlName: 'biometric_prompt_title', value: 'Authentication required', type: 'string', configKey: 'BIOMETRIC_PROMPT_TITLE' },
+    { stringsXmlName: 'biometric_prompt_subtitle', value: 'Please authenticate to continue', type: 'string', configKey: 'BIOMETRIC_PROMPT_SUBTITLE'  },
+    { stringsXmlName: 'biometric_prompt_negative_button', value: 'Cancel', type: 'string', configKey: 'BIOMETRIC_PROMPT_NEGATIVE_BTN'  }
+];
+for (const { stringsXmlName, value, type, configKey } of valuesToAdd) {
+    if (!elementExists(type, stringsXmlName, configKey)) {
+        const stringElement = stringsXmlDoc.createElement(type);
+        stringElement.setAttribute('name', stringsXmlName);
+        stringElement.textContent = value;
+        stringsXmlDoc.documentElement.appendChild(stringElement);
+        writtenValuesCount = writtenValuesCount + 1;
+    }
+}
+
+if (writtenValuesCount > 0) {
+    // Serialize and write the updated XML file
+    const serializer = new XMLSerializer();
+    let updatedXmlString = serializer.serializeToString(stringsXmlDoc);
+    // XMLSerializer doesn't properly indent the content, so it is manually done here
+    updatedXmlString = updatedXmlString
+        .replace(/>(\s*)</g, '>\n<') // put each tag on its own line
+        .replace(/<([^?\/][^>]*)>/g, '    <$1>') // indent all opening tags except <?xml ...?>
+        .replace(/ {4}(<\/?resources>)/g, '$1') // remove indentation from initial <resources> tag
+    fs.writeFileSync(stringsXmlPath, updatedXmlString, 'utf-8');
+    console.log("\t[SUCESSS] Added " + writtenValuesCount + " out of expected " + valuesToAdd.length + " values into strings.xml");
+} else {
+    console.log("\t[SKIPPED] Values already exist in strings.xml");
+}
+
+function elementExists(tagName, nameValue, configKey) {
+    return elementExistsInStringsXml(tagName, nameValue) || elementExistsInCapacitorConfig(configKey);
+}
+
+function elementExistsInStringsXml(tagName, nameValue) {
+    const elements = stringsXmlDoc.getElementsByTagName(tagName);
+    for (let i = 0; i < elements.length; i++) {
+        if (elements[i].getAttribute('name') === nameValue) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function elementExistsInCapacitorConfig(configKey) {
+    // Such elements in capacitor config should be written into strings.xml later
+    // through a different build actions file (KeyStore plugin)
+    return getConfigValue(configJsonContent, configKey) != undefined;
+}
+
+function getConfigValue(config, key) {
+    if (!config || !config.outsystems || !config.outsystems.buildConfigurations || 
+        !config.outsystems.buildConfigurations.buildActions || !config.outsystems.buildConfigurations.buildActions[0] ||
+        !config.outsystems.buildConfigurations.buildActions[0].parameters) {
+        return undefined;
+    }
+    return config.outsystems.buildConfigurations.buildActions[0].parameters[key];
+}

--- a/build-actions/update_strings_for_keystore.js
+++ b/build-actions/update_strings_for_keystore.js
@@ -14,7 +14,7 @@ if (platform != 'android') {
 console.log("\nCiphered Local Storage Plugin - running hook after update - for " + platform);
 
 const stringsXmlPath = path.join(projectRoot, 'android/app/src/main/res/values/strings.xml');
-const jsonConfigPath = path.join(projectRoot, "capacitor.config.json");
+const jsonConfigPath = path.join(projectRoot, "outsystems.config.json");
 if (!fs.existsSync(stringsXmlPath)) {
    console.error("\t[ERROR] - strings.xml file does not exist, and is required by this hook - " + stringsXmlPath);
    process.exit(1);
@@ -82,10 +82,10 @@ function elementExistsInCapacitorConfig(configKey) {
 }
 
 function getConfigValue(config, key) {
-    if (!config || !config.outsystems || !config.outsystems.buildConfigurations || 
-        !config.outsystems.buildConfigurations.buildActions || !config.outsystems.buildConfigurations.buildActions[0] ||
-        !config.outsystems.buildConfigurations.buildActions[0].parameters) {
+    if (!config || !config.buildConfigurations || 
+        !config.buildConfigurations.buildActions || !config.buildConfigurations.buildActions[0] ||
+        !config.buildConfigurations.buildActions[0].parameters) {
         return undefined;
     }
-    return config.outsystems.buildConfigurations.buildActions[0].parameters[key];
+    return config.buildConfigurations.buildActions[0].parameters[key];
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
       "version": ">=3.3.0"
     }
   ],
+  "scripts": {
+    "capacitor:update:after": "node build-actions/update_strings_for_keystore.js"
+  },
   "author": "OutSystems",
   "license": "MIT",
   "bugs": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,7 @@
     </js-module>
 
     <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git#0.1.7-OS9" />
-    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#2.6.8-OS21" />
+    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#2.6.8-OS22" />
     
     <dependency id="outsystems-plugin-disable-backup" url="https://github.com/OutSystems/outsystems-plugin-disable-backup.git#1.0.2" />
 


### PR DESCRIPTION
## Description

This PR adds the necessary changes for support for Capacitor in OutSystems apps (with MABS 12), by adding the necessary build actions and Capacitor Hooks.

Note that the plugin has a few dependencies, but these don't need additional changes for Capacitor support. The one exception is `outsystems-plugin-disable-backup`, whose hook is now a build actions for MABS 12 builds.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->

References: https://outsystemsrd.atlassian.net/browse/RMET-4190

<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [x] iOS platform
- [ ] JavaScript
- [x] OutSystems

## Tests

Test with MABS 12 builds of the Ciphered Local Storage Demo App: https://eng-mobile.outsystems.dev/apps/application?id=181f541f-34a1-4ee0-b148-4fe0ee227ec7&stageid=82798f0c-48de-4787-b0e1-dd3204ce2e6b&tab=mobiledistribution

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly