### PR TITLE
 fix(ios): Update dependencies with removed bitcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.2.6] - 2026-02-05
+- Fix: [iOS] Remove bitcode by updating dependency to cordova-plugin-secure-storage plugin to use version `2.6.8-OS28` (https://outsystemsrd.atlassian.net/browse/RMET-4924).
+
 ## [2.2.5] - 2026-01-13
 - Chore: [Android] Update dependency to cordova-plugin-secure-storage plugin to use version `2.6.8-OS27` (https://outsystemsrd.atlassian.net/browse/RMET-4900).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.SecureSQLiteBundle",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Bundle of SQLite related storage plugins and initialization code for easy use with the OutSystems Platform",
   "cordova": {
     "id": "com.outsystems.plugins.SecureSQLiteBundle",

--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,7 @@
     </js-module>
 
     <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git#0.1.7-OS10" />
-    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#2.6.8-OS27" />
+    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#2.6.8-OS28" />
     
     <dependency id="outsystems-plugin-disable-backup" url="https://github.com/OutSystems/outsystems-plugin-disable-backup.git#1.0.2" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="com.outsystems.plugins.SecureSQLiteBundle"
-    version="2.2.5">
+    version="2.2.6">
 
     <name>Cordova OutSystems secure SQLite bundle</name>
     <license>MIT</license>


### PR DESCRIPTION
## Description

This PR includes a re-built version of `OSKeyStoreLib` without bitcode - via the cordova-plugin-secure-storage dependency at https://github.com/OutSystems/cordova-plugin-secure-storage/pull/44

## Context

To address issues with Apple App Store submissions - https://outsystemsrd.atlassian.net/browse/RMET-4924

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests

A succesful app store submission with this plugin can be seen in Apple Developer Account "OutSystems Inc" -> KeyStore MABS 12 Capacitor (version code 102)

You may also check with "Ciphered Local Storage Demo App" in ODC that everything is still working.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly