### PR TITLE
fix(ios): update to version 2.6.8-OS29 of cordova-plugin-secure-storage to fix MABS 11.2 builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.2.8] - 2026-02-13
-- Fix [iOS]: Update dependency to cordova-plugin-secure-storage plugin to use version `2.6.8-OS29` (https://outsystemsrd.atlassian.net/browse/RMET-5030).
-
-## [2.2.7] - 2026-02-13
+## [2.2.7] - 2026-03-09
 - Fix: Update dependency to cordova-sqlcipher-adapter plugin to use version `0.1.7-OS11` (https://outsystemsrd.atlassian.net/browse/RMET-4293).
+- Fix [iOS]: Update dependency to cordova-plugin-secure-storage plugin to use version `2.6.8-OS29` (https://outsystemsrd.atlassian.net/browse/RMET-5030).
 
 ## [2.2.6] - 2026-02-05
 - Fix: [iOS] Remove bitcode by updating dependency to cordova-plugin-secure-storage plugin to use version `2.6.8-OS28` (https://outsystemsrd.atlassian.net/browse/RMET-4924).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.2.8] - 2026-02-13
+- Fix [iOS]: Update dependency to cordova-plugin-secure-storage plugin to use version `2.6.8-OS29` (https://outsystemsrd.atlassian.net/browse/RMET-5030).
+
 ## [2.2.7] - 2026-02-13
 - Fix: Update dependency to cordova-sqlcipher-adapter plugin to use version `0.1.7-OS11` (https://outsystemsrd.atlassian.net/browse/RMET-4293).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.SecureSQLiteBundle",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "description": "Bundle of SQLite related storage plugins and initialization code for easy use with the OutSystems Platform",
   "cordova": {
     "id": "com.outsystems.plugins.SecureSQLiteBundle",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.SecureSQLiteBundle",
-  "version": "2.2.8",
+  "version": "2.2.7",
   "description": "Bundle of SQLite related storage plugins and initialization code for easy use with the OutSystems Platform",
   "cordova": {
     "id": "com.outsystems.plugins.SecureSQLiteBundle",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="com.outsystems.plugins.SecureSQLiteBundle"
-    version="2.2.8">
+    version="2.2.7">
 
     <name>Cordova OutSystems secure SQLite bundle</name>
     <license>MIT</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="com.outsystems.plugins.SecureSQLiteBundle"
-    version="2.2.7">
+    version="2.2.8">
 
     <name>Cordova OutSystems secure SQLite bundle</name>
     <license>MIT</license>
@@ -15,7 +15,7 @@
     </js-module>
 
     <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git#0.1.7-OS11" />
-    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#2.6.8-OS28" />
+    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#2.6.8-OS29" />
     
     <dependency id="outsystems-plugin-disable-backup" url="https://github.com/OutSystems/outsystems-plugin-disable-backup.git#1.0.2" />
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Brings fix from https://github.com/OutSystems/cordova-plugin-secure-storage/pull/46

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

MABS 11.2 build: https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=2c0e31d73cf6ba7c362f2c7d15f396ae9feb6e26&stg=dev

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
