### PR TITLE
feat: Support for SPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+# Swift Package Manager
+.build/
+.swiftpm/
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -10,17 +10,13 @@ let package = Package(
             targets: ["SecureSQLiteBundlePlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apache/cordova-ios.git", branch: "master"),
-        .package(url: "https://github.com/OutSystems/cordova-plugin-secure-storage.git", branch: "feat/RMET-5136/spm"),
-        .package(url: "https://github.com/OutSystems/Cordova-sqlcipher-adapter.git", branch: "feat/RMET-5136/spm")
+        .package(url: "https://github.com/apache/cordova-ios.git", branch: "master")
     ],
     targets: [
         .target(
             name: "SecureSQLiteBundlePlugin",
             dependencies: [
-                .product(name: "Cordova", package: "cordova-ios"),
-                .product(name: "cordova-plugin-secure-storage", package: "cordova-plugin-secure-storage"),
-                .product(name: "cordova-sqlcipher-adapter", package: "cordova-sqlcipher-adapter")
+                .product(name: "Cordova", package: "cordova-ios")
             ],
             path: "src/ios")
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -3,11 +3,11 @@ import PackageDescription
 
 let package = Package(
     name: "com.outsystems.plugins.SecureSQLiteBundle",
-    platforms: [.iOS(.v14)],
+    platforms: [.iOS(.v15)],
     products: [
         .library(
             name: "com.outsystems.plugins.SecureSQLiteBundle",
-            targets: ["com.outsystems.plugins.SecureSQLiteBundle"])
+            targets: ["SecureSQLiteBundlePlugin"])
     ],
     dependencies: [
         .package(url: "https://github.com/apache/cordova-ios.git", branch: "master"),
@@ -16,7 +16,7 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "com.outsystems.plugins.SecureSQLiteBundle",
+            name: "SecureSQLiteBundlePlugin",
             dependencies: [
                 .product(name: "Cordova", package: "cordova-ios"),
                 .product(name: "cordova-plugin-secure-storage", package: "cordova-plugin-secure-storage"),

--- a/Package.swift
+++ b/Package.swift
@@ -1,36 +1,23 @@
 // swift-tools-version:5.9
 import PackageDescription
 
-// NOTE: Once SPM support is validated and sub-plugins are tagged, replace .branch(...)
-// with .exact("new-version-tag") for each dependency.
 let package = Package(
-    name: "cordova-outsystems-secure-sqlite-bundle",
+    name: "com.outsystems.plugins.SecureSQLiteBundle",
+    platforms: [.iOS(.v14)],
     products: [
         .library(
-            name: "cordova-outsystems-secure-sqlite-bundle",
-            targets: ["cordova-outsystems-secure-sqlite-bundle"]
-        )
+            name: "com.outsystems.plugins.SecureSQLiteBundle",
+            targets: ["com.outsystems.plugins.SecureSQLiteBundle"])
     ],
     dependencies: [
-        .package(
-            url: "https://github.com/OutSystems/cordova-sqlcipher-adapter.git",
-            branch: "feat/RMET-5136/spm"
-        ),
-        .package(
-            url: "https://github.com/OutSystems/cordova-plugin-secure-storage.git",
-            branch: "feat/RMET-5136/spm"
-        )
+        .package(url: "https://github.com/apache/cordova-ios.git", branch: "master")
     ],
     targets: [
         .target(
-            name: "cordova-outsystems-secure-sqlite-bundle",
+            name: "com.outsystems.plugins.SecureSQLiteBundle",
             dependencies: [
-                .product(name: "cordova-sqlcipher-adapter",
-                         package: "cordova-sqlcipher-adapter"),
-                .product(name: "cordova-plugin-secure-storage",
-                         package: "cordova-plugin-secure-storage")
+                .product(name: "Cordova", package: "cordova-ios")
             ],
-            path: "src/ios"
-        )
+            path: "src/ios")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+// NOTE: Once SPM support is validated and sub-plugins are tagged, replace .branch(...)
+// with .exact("new-version-tag") for each dependency.
+let package = Package(
+    name: "cordova-outsystems-secure-sqlite-bundle",
+    products: [
+        .library(
+            name: "cordova-outsystems-secure-sqlite-bundle",
+            targets: ["cordova-outsystems-secure-sqlite-bundle"]
+        )
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/OutSystems/cordova-sqlcipher-adapter.git",
+            branch: "feat/RMET-5136/spm"
+        ),
+        .package(
+            url: "https://github.com/OutSystems/cordova-plugin-secure-storage.git",
+            branch: "feat/RMET-5136/spm"
+        )
+    ],
+    targets: [
+        .target(
+            name: "cordova-outsystems-secure-sqlite-bundle",
+            dependencies: [
+                .product(name: "cordova-sqlcipher-adapter",
+                         package: "cordova-sqlcipher-adapter"),
+                .product(name: "cordova-plugin-secure-storage",
+                         package: "cordova-plugin-secure-storage")
+            ],
+            path: "src/ios"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -10,13 +10,17 @@ let package = Package(
             targets: ["com.outsystems.plugins.SecureSQLiteBundle"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apache/cordova-ios.git", branch: "master")
+        .package(url: "https://github.com/apache/cordova-ios.git", branch: "master"),
+        .package(url: "https://github.com/OutSystems/cordova-plugin-secure-storage.git", branch: "feat/RMET-5136/spm"),
+        .package(url: "https://github.com/OutSystems/Cordova-sqlcipher-adapter.git", branch: "feat/RMET-5136/spm")
     ],
     targets: [
         .target(
             name: "com.outsystems.plugins.SecureSQLiteBundle",
             dependencies: [
-                .product(name: "Cordova", package: "cordova-ios")
+                .product(name: "Cordova", package: "cordova-ios"),
+                .product(name: "cordova-plugin-secure-storage", package: "cordova-plugin-secure-storage"),
+                .product(name: "cordova-sqlcipher-adapter", package: "cordova-sqlcipher-adapter")
             ],
             path: "src/ios")
     ]

--- a/build-actions/update_strings_for_keystore.js
+++ b/build-actions/update_strings_for_keystore.js
@@ -1,8 +1,6 @@
 const path = require('path');
 const fs = require('fs');
-const { DOMParser, XMLSerializer } = require('xmldom');
 
-const parser = new DOMParser();
 const platform = process.env.CAPACITOR_PLATFORM_NAME;
 const projectRoot = process.env.CAPACITOR_ROOT_DIR;
 
@@ -10,6 +8,9 @@ if (platform != 'android') {
     // hook only needs to run for Android
     return
 }
+
+const { DOMParser, XMLSerializer } = require('xmldom');
+const parser = new DOMParser();
 
 console.log("\nCiphered Local Storage Plugin - running hook before update - for " + platform);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "com.outsystems.plugins.SecureSQLiteBundle",
+  "version": "2.2.7",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "com.outsystems.plugins.SecureSQLiteBundle",
+      "version": "2.2.7",
+      "engines": [
+        {
+          "name": "cordova",
+          "version": ">=3.3.0"
+        }
+      ],
+      "license": "MIT"
+    }
+  }
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -16,7 +16,7 @@
 
     <!-- iOS: placeholder source file so Capacitor creates the SPM sources directory -->
     <platform name="ios" package="swift">
-        <source-file src="src/ios/SecureSQLiteBundle.swift" />
+        <source-file src="src/ios/SecureSQLiteBundle.swift" nospm="true" />
     </platform>
 
     <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git#0.1.7-OS11" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,7 @@
     </js-module>
 
     <!-- iOS: placeholder source file so Capacitor creates the SPM sources directory -->
-    <platform name="ios">
+    <platform name="ios" package="swift">
         <source-file src="src/ios/SecureSQLiteBundle.swift" />
     </platform>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -14,6 +14,11 @@
         <clobbers target="OutSystemsSecureSQLiteBundle" />
     </js-module>
 
+    <!-- iOS: placeholder source file so Capacitor creates the SPM sources directory -->
+    <platform name="ios">
+        <source-file src="src/ios/SecureSQLiteBundle.swift" />
+    </platform>
+
     <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git#0.1.7-OS11" />
     <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#2.6.8-OS29" />
     

--- a/plugin.xml
+++ b/plugin.xml
@@ -16,7 +16,7 @@
 
     <!-- iOS: placeholder source file so Capacitor creates the SPM sources directory -->
     <platform name="ios" package="swift">
-        <source-file src="src/ios/SecureSQLiteBundle.swift" nospm="true" />
+        <source-file src="src/ios/SecureSQLiteBundle.swift"/>
     </platform>
 
     <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/Cordova-sqlcipher-adapter.git#feat/RMET-5136/spm" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,8 +19,8 @@
         <source-file src="src/ios/SecureSQLiteBundle.swift" nospm="true" />
     </platform>
 
-    <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/cordova-sqlcipher-adapter.git#0.1.7-OS11" />
-    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#2.6.8-OS29" />
+    <dependency id="cordova-sqlcipher-adapter" url="https://github.com/OutSystems/Cordova-sqlcipher-adapter.git#feat/RMET-5136/spm" />
+    <dependency id="cordova-plugin-secure-storage" url="https://github.com/OutSystems/cordova-plugin-secure-storage.git#feat/RMET-5136/spm" />
     
     <dependency id="outsystems-plugin-disable-backup" url="https://github.com/OutSystems/outsystems-plugin-disable-backup.git#1.0.2" />
 

--- a/src/ios/SecureSQLiteBundle.swift
+++ b/src/ios/SecureSQLiteBundle.swift
@@ -1,0 +1,3 @@
+// SPM target placeholder — native work is fully delegated to sub-plugins:
+// - cordova-sqlcipher-adapter (SQLCipher encrypted SQLite)
+// - cordova-plugin-secure-storage (OS keychain/keystore)


### PR DESCRIPTION
**This PR adds support for SPM by:**

- Adding a `Package.swift` file with the required dependencies for SPM support.
- Updating `plugin.xml` to add `package="swift"` on the iOS platform and `nospm="true"` on all iOS source files, so the SPM build path uses `Package.swift` exclusively

⚠️ Note: This PR is dependent on the adapter and secure-storage SPM PRs. Once those are reviewed and merged, the references to `feat/RMET-5136/spm` in `plugin.xml` and `Package.swift` will need to be updated to point to the correct released tags before this PR can be merged.

- OutSystems/Cordova-sqlcipher-adapter#18
- OutSystems/cordova-plugin-secure-storage#47

**Tests**

✅ Cordova iOS CocoaPods — no regression [ciphered-cdv ipa](https://github.com/user-attachments/files/27016869/ciphered-cdv.ipa.zip)
✅ Capacitor iOS CocoaPods — no regression [ciphered-cap ipa](https://github.com/user-attachments/files/27016906/ciphered-cap.ipa.zip)
❌ Capacitor iOS SPM — not yet tested, blocked by missing implementation in Capacitor CLI — [RMET-5117](https://outsystemsrd.atlassian.net/browse/RMET-5117)

However, you can use this sample app to test [zip attached](https://github.com/user-attachments/files/27018600/capacitor-ciphered-exampleapp.zip)

**Note:** do not run `npm install`, as the `package.json` points to local paths. The `node_modules` in the zip are already set up and ready to test, just open the app in Xcode and build.

**References**

https://outsystemsrd.atlassian.net/browse/RMET-5136

[RMET-5117]: https://outsystemsrd.atlassian.net/browse/RMET-5117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ